### PR TITLE
Refactored rook & bishop move validation and centralised target square checking

### DIFF
--- a/src/logic/chesspieces/chess_piece.php
+++ b/src/logic/chesspieces/chess_piece.php
@@ -69,17 +69,6 @@ abstract class ChessPiece implements JsonSerializable
         return $this->has_moved;
     }
 
-    protected function check_target_square(mixed $chessboard, Move $move):bool
-    {
-        if($chessboard[$move->to_x][$move->to_y]==""){
-            return true;
-        }
-        if($chessboard[$move->from_x][$move->from_y]->get_color()!=$chessboard[$move->to_x][$move->to_y]->get_color()){
-            return true;
-        }else{
-            return false;
-        }
-    }
     # ---abstract methods---
     abstract function check_move_legal(mixed $chessboard, Move $move):bool;
 

--- a/src/logic/chesspieces/king.php
+++ b/src/logic/chesspieces/king.php
@@ -21,15 +21,12 @@ class King extends ChessPiece
 
       if($distance_x <= 1 && $distance_y <= 1){
         # check if there is a piece on the move to square 
-         if($chessboard[$move->to_x][$move->to_y] instanceof ChessPiece){
-          return true;
-         }elseif(!$chessboard[$move->to_x][$move->to_y] instanceof ChessPiece){
-          return true;
-         }
+         return true;
       }
 
+      # castling moves
       if($this->has_moved==false){
-      # castling short as white
+        # castling short as white
         if($this->color=='white' && $move->to_x==7 && $move->to_y==1){
             if(!$chessboard[6][1] instanceof ChessPiece && !$chessboard[7][1] instanceof ChessPiece){
               if($chessboard[8][1] instanceof Rook && $chessboard[8][1]->has_moved==false){

--- a/src/logic/chesspieces/king.php
+++ b/src/logic/chesspieces/king.php
@@ -20,8 +20,8 @@ class King extends ChessPiece
       $distance_y = sqrt(pow(($move->to_y-$move->from_y),2)); 
 
       if($distance_x <= 1 && $distance_y <= 1){
-        # check if there is a piece on the move to square and if it is opposite color
-         if($chessboard[$move->to_x][$move->to_y] instanceof ChessPiece &&  $chessboard[$move->from_x][$move->from_y]->get_color()!=$chessboard[$move->to_x][$move->to_y]->get_color()){
+        # check if there is a piece on the move to square 
+         if($chessboard[$move->to_x][$move->to_y] instanceof ChessPiece){
           return true;
          }elseif(!$chessboard[$move->to_x][$move->to_y] instanceof ChessPiece){
           return true;

--- a/src/logic/chesspieces/knight.php
+++ b/src/logic/chesspieces/knight.php
@@ -35,15 +35,11 @@ class Knight extends ChessPiece
              $move->to_y==$move->from_y-2 && $move->to_x==$move->from_x+1||
              $move->to_y==$move->from_y-2 && $move->to_x==$move->from_x-1){
           if($chessboard[$move->to_x][$move->to_y] instanceof ChessPiece){
-              if($chessboard[$move->from_x][$move->from_y]->get_color()!=$chessboard[$move->to_x][$move->to_y]->get_color()){
                 return true;
-              }
           }else{
             return true;
           }
         }
-
-        $_SESSION['error'] = "<p class='error'>knights can't move like that</p>";
 
         return false;
     }

--- a/src/logic/chesspieces/pawn.php
+++ b/src/logic/chesspieces/pawn.php
@@ -27,8 +27,7 @@ class Pawn extends ChessPiece
     return ($this->check_moving_onesquare_forwards($chessboard, $move) or
       $this->check_moving_twosquares_forwards($chessboard, $move) or
       $this->check_diagonal_move($chessboard, $move) or
-      $this->check_enpassant($move)) and
-      $this->check_target_square($chessboard, $move);
+      $this->check_enpassant($move));
   }
 
 

--- a/src/logic/chesspieces/traits.php
+++ b/src/logic/chesspieces/traits.php
@@ -14,22 +14,19 @@ trait RookTrait
             if ($move->from_x < $move->to_x) {
                 for ($i = 1; $i <= $distance_x; $i++) {
                     $move_to_field = $chessboard[$move->from_x + $i][$move->from_y];
-                    if($this->check_file_move($move_to_field, $i, $distance_x)){
+                    if(check_file_move($move_to_field, $i, $distance_x)){
                         return true;
-                    }else{
-                        return false;
-                    }   
+                    }
+                    return false;
                 }
-                return false;
                 # check if its moving to the left
             } elseif ($move->to_x < $move->from_x) {
                 for ($i = 1; $i <= $distance_x; $i++) {
                     $move_to_field = $chessboard[$move->from_x - $i][$move->from_y];
-                    if($this->check_file_move($move_to_field, $i, $distance_x)){
+                    if(check_file_move($move_to_field, $i, $distance_x)){
                         return true;
-                    }else{
-                        return false;
-                    } 
+                    }
+                    return false;
                 }
             }
         }
@@ -40,21 +37,19 @@ trait RookTrait
             if($move->from_y<$move->to_y){
                 for ($i=1; $i<= $distance_y; $i++) { 
                     $move_to_field = $chessboard[$move->from_x][$move->from_y+$i];
-                    if($this->check_file_move($move_to_field, $i, $distance_y)){
+                    if(check_file_move($move_to_field, $i, $distance_x)){
                         return true;
-                    }else{
-                        return false;
-                    }   
+                    }
+                    return false;
                 }
                 # check if moving down
             }elseif ($move->to_y<$move->from_y) {
                 for ($i=1; $i<= $distance_y; $i++) {
                     $move_to_field = $chessboard[$move->from_x][$move->from_y-$i]; # check if there is a piece on the way 
-                    if($this->check_file_move($move_to_field, $i, $distance_y)){
+                    if(check_file_move($move_to_field, $i, $distance_x)){
                         return true;
-                    }else{
-                        return false;
-                    } 
+                    }
+                    return false;
                 }
             }
             return true;
@@ -62,17 +57,7 @@ trait RookTrait
         return false;
     }
 
-    private function check_file_move($move_to_field, $index, $distance){
-        if(!$move_to_field instanceof ChessPiece) // No piece on the way
-            {
-                return true;
-            }
-        if($distance==$index && $move_to_field instanceof ChessPiece) // Piece on last square is allowed
-            {
-                return true;
-            }
-        return false;
-    }
+
 }
 
 trait BishopTrait{
@@ -89,57 +74,37 @@ trait BishopTrait{
             if($move->from_x<$move->to_x && $move->from_y<$move->to_y){
                 for ($i=1; $i <= $distance; $i++) { 
                     $move_to_field = $chessboard[$move->from_x+$i][$move->from_y+$i];
-                    if($move_to_field instanceof ChessPiece){ // check if there is a piece on the way
-                        if($i==$distance  && $move_to_field->get_color()!= $move_from_field->get_color()){ // target square can be taken
-                            return true;
-                        }else{
-                            return false;
-                        }
-                    }elseif($i==$distance){ // no piece on the way
+                    if(check_file_move($move_to_field, $i, $distance)){
                         return true;
                     }
+                    return false;
                 }
             # top left
             }elseif($move->from_x>$move->to_x && $move->from_y<$move->to_y){
                 for ($i=1; $i <= $distance; $i++) {
                     $move_to_field = $chessboard[$move->from_x-$i][$move->from_y+$i]; 
-                    if($move_to_field instanceof ChessPiece){
-                        if($i==$distance  && $move_from_field->get_color()!= $move_to_field->get_color()){
-                            return true;
-                        }else{
-                            return false;
-                        }
-                    }elseif($i==$distance){
+                    if(check_file_move($move_to_field, $i, $distance)){
                         return true;
                     }
+                    return false;
                 }
             # bottom left
             }elseif($move->from_x>$move->to_x && $move->from_y>$move->to_y){
                 for ($i=1; $i <= $distance; $i++) {
                     $move_to_field = $chessboard[$move->from_x-$i][$move->from_y-$i]; 
-                    if($move_to_field instanceof ChessPiece){
-                        if($i==$distance && $move_from_field->get_color()!= $move_to_field->get_color()){
-                            return true;
-                        }else{
-                            return false;
-                        }
-                    }elseif($i==$distance){
+                    if(check_file_move($move_to_field, $i, $distance)){
                         return true;
                     }
+                    return false;
                 }
             # bottom right
             }elseif($move->from_x<$move->to_x && $move->from_y>$move->to_y){
                 for ($i=1; $i <= $distance; $i++) {
                     $move_to_field = $chessboard[$move->from_x+$i][$move->from_y-$i]; 
-                    if($move_to_field instanceof ChessPiece){
-                        if($i==$distance  && $move_from_field->get_color()!= $move_to_field->get_color()){
-                            return true;
-                        }else{
-                            return false;
-                        }
-                    }elseif($i==$distance){
+                    if(check_file_move($move_to_field, $i, $distance)){
                         return true;
                     }
+                    return false;
                 }
             }
             return false;
@@ -147,4 +112,17 @@ trait BishopTrait{
     return false; # not a diagonal move
     }
 
+}
+
+ function check_file_move($move_to_field, $index, $distance){
+    if($move_to_field instanceof ChessPiece){ // check if there is a piece on the way
+        if($index==$distance){ // target square can be taken
+            return true;
+        }else{ // piece on the way and not last move
+            return false;
+        }
+    }elseif($index==$distance){ // no piece on the way
+        return true;
+    } 
+    return false;
 }

--- a/src/logic/chesspieces/traits.php
+++ b/src/logic/chesspieces/traits.php
@@ -16,7 +16,9 @@ trait RookTrait
                     $move_to_field = $chessboard[$move->from_x + $i][$move->from_y];
                     if($this->check_file_move($move_to_field, $i, $distance_x)){
                         return true;
-                    }
+                    }else{
+                        return false;
+                    }   
                 }
                 return false;
                 # check if its moving to the left
@@ -25,10 +27,11 @@ trait RookTrait
                     $move_to_field = $chessboard[$move->from_x - $i][$move->from_y];
                     if($this->check_file_move($move_to_field, $i, $distance_x)){
                         return true;
-                    }
+                    }else{
+                        return false;
+                    } 
                 }
             }
-            return true;
         }
 
         #check if its vertically
@@ -39,7 +42,9 @@ trait RookTrait
                     $move_to_field = $chessboard[$move->from_x][$move->from_y+$i];
                     if($this->check_file_move($move_to_field, $i, $distance_y)){
                         return true;
-                    }
+                    }else{
+                        return false;
+                    }   
                 }
                 # check if moving down
             }elseif ($move->to_y<$move->from_y) {
@@ -47,7 +52,9 @@ trait RookTrait
                     $move_to_field = $chessboard[$move->from_x][$move->from_y-$i]; # check if there is a piece on the way 
                     if($this->check_file_move($move_to_field, $i, $distance_y)){
                         return true;
-                    }
+                    }else{
+                        return false;
+                    } 
                 }
             }
             return true;

--- a/src/logic/chesspieces/traits.php
+++ b/src/logic/chesspieces/traits.php
@@ -2,23 +2,25 @@
 trait RookTrait
 {
     public function check_legal_rookmove(mixed $chessboard, Move $move): bool
-    {
+    {   
         # distance in squares
         $distance_x = sqrt(pow(($move->to_x-$move->from_x),2)); 
         $distance_y = sqrt(pow(($move->to_y-$move->from_y),2)); 
 
        # check if its horizontally
         if ($move->from_y == $move->to_y && $move->from_x != $move->to_x) {
-
             # check if moving to the right
             if ($move->from_x < $move->to_x) {
-                if(check_direction($chessboard, $move, $distance_x, "positiv", "x")){
+                if(check_direction($chessboard, $move, $distance_x, "+x")){
                     return true;
-                }
-                
+                }else{
+                    return false;
+                }  
             } elseif ($move->to_x < $move->from_x) { # check if it a move to the left
-                if(check_direction($chessboard, $move, $distance_x, "negativ", "x")){
+                if(check_direction($chessboard, $move, $distance_x, "-x")){
                     return true;
+                }else{
+                    return false;
                 }
             }
         }
@@ -27,114 +29,111 @@ trait RookTrait
         if ($move->from_x == $move->to_x && $move->from_y != $move->to_y) {
             # check if moving up
             if($move->from_y<$move->to_y){
-                if(check_direction($chessboard, $move, $distance_y, "positiv", "y")){
+                if(check_direction($chessboard, $move, $distance_y, "+y")){
                     return true;
+                }else{
+                    return false;
                 }
                 # check if moving down
             }elseif ($move->to_y<$move->from_y) {
-                if(check_direction($chessboard, $move, $distance_y, "negativ", "y")){
+                if(check_direction($chessboard, $move, $distance_y, "-y")){
                     return true;
+                }else{
+                    return false;
                 }
             }
             return false;
         }
         return false;
     }
-
-
-
 }
 
 trait BishopTrait{
     public function check_legal_bishopmove(mixed $chessboard, Move $move):bool
-    {
+    {  
         # check if its diagonal move
         if(pow($move->from_x-$move->to_x,2) == pow($move->from_y-$move->to_y,2)){
 
             $distance = sqrt(pow($move->from_x-$move->to_x,2)); # distance in squares
-
-            # top right - check if piece on the way
+            # top right 
             if($move->from_x<$move->to_x && $move->from_y<$move->to_y){
-                for ($i=1; $i <= $distance; $i++) { 
-                    $move_to_field = $chessboard[$move->from_x+$i][$move->from_y+$i];
-                    if(no_piece_in_way($move_to_field, $i, $distance)){
-                        return true;
-                    }else{
-                        return false;
-                    }
-                }
-                
+                if(check_direction($chessboard, $move, $distance, "++")){
+                    return true;
+                }else{
+                    return false;
+                } 
             # top left
             }elseif($move->from_x>$move->to_x && $move->from_y<$move->to_y){
-                for ($i=1; $i <= $distance; $i++) {
-                    $move_to_field = $chessboard[$move->from_x-$i][$move->from_y+$i]; 
-                    if(no_piece_in_way($move_to_field, $i, $distance)){
-                        return true;
-                    }else{
-                        return false;
-                    }
+                if(check_direction($chessboard, $move, $distance, "-+")){
+                    return true;
+                }else{
+                    return false;
                 }
             # bottom left
             }elseif($move->from_x>$move->to_x && $move->from_y>$move->to_y){
-                for ($i=1; $i <= $distance; $i++) {
-                    $move_to_field = $chessboard[$move->from_x-$i][$move->from_y-$i]; 
-                    if(no_piece_in_way($move_to_field, $i, $distance)){
-                        return true;
-                    }else{
-                        return false;
-                    }
+                if(check_direction($chessboard, $move, $distance, "--")){
+                    return true;
+                }else{
+                    return false;
                 }
                 return false;
             # bottom right
             }elseif($move->from_x<$move->to_x && $move->from_y>$move->to_y){
-                for ($i=1; $i <= $distance; $i++) {
-                    $move_to_field = $chessboard[$move->from_x+$i][$move->from_y-$i]; 
-                    if(no_piece_in_way($move_to_field, $i, $distance)){
-                        return true;
-                    }else{
-                        return false;
-                    }
+                if(check_direction($chessboard, $move, $distance, "+-")){
+                    return true;
+                }else{
+                    return false;
                 }
             }
         }
     return false; # not a diagonal move
     }
-
 }
 
-function no_piece_in_way(mixed $move_to_field, int $index, int $distance):bool
+function piece_in_way(mixed $move_to_field, int $index, int $distance):bool
 {
     if($move_to_field instanceof ChessPiece){ // check if there is a piece on the way
         if($index==$distance){ // target square can be taken
-            return true;
+            return false;
         }else{ // piece on the way and not last move
+            return true;
+        }
+    }
+    return false;
+}
+
+function check_direction($chessboard, Move $move, int $distance, String $direction): bool
+{
+    for ($i=1; $i <= $distance; $i++) { 
+        $move_to_field = get_move_to_field($chessboard, $move, $direction, $i);
+
+        if(piece_in_way($move_to_field, $i, $distance)){
             return false;
         }
-    }elseif($index==$distance){ // no piece on the way
-        return true;
-    } 
+    }
     return true;
 }
 
-function check_direction($chessboard, Move $move, int $distance, String $sign, String $direction): bool
+function get_move_to_field(mixed $chessboard, Move $move, String $direction, $i):mixed
 {
-    for ($i = 1; $i <= $distance; $i++) {
-        if($sign == "negativ"){
-            $i = -$i;
-        }
-
-        if($direction == "x"){
-            $move_to_field = $chessboard[$move->from_x + $i][$move->from_y];
-        }elseif($direction == "y"){
-            $move_to_field = $chessboard[$move->from_x][$move->from_y + $i];
-        }
-        
-        if(no_piece_in_way($move_to_field, $i, $distance)){
-            
-        }else{
-            return false;
-        }
-        
-        return true;
+    if($direction == "+x"){
+        $move_to_field = $chessboard[$move->from_x + $i][$move->from_y];
+    }elseif($direction == "+y"){
+        $move_to_field = $chessboard[$move->from_x][$move->from_y + $i];
+    }elseif($direction == "-x"){
+        $move_to_field = $chessboard[$move->from_x - $i][$move->from_y];
+    }elseif($direction == "-y"){
+        $move_to_field = $chessboard[$move->from_x][$move->from_y - $i];
+    }elseif($direction == "++"){
+        $move_to_field = $chessboard[$move->from_x + $i][$move->from_y + $i];
+    }elseif($direction == "--"){
+        $move_to_field = $chessboard[$move->from_x - $i][$move->from_y - $i];
+    }elseif($direction == "+-"){
+        $move_to_field = $chessboard[$move->from_x + $i][$move->from_y - $i];
+    }elseif($direction == "-+"){
+        $move_to_field = $chessboard[$move->from_x - $i][$move->from_y + $i];
+    }else{
+        throw new Exception("Invalid direction");
     }
+    return $move_to_field;
 }

--- a/src/logic/chesspieces/traits.php
+++ b/src/logic/chesspieces/traits.php
@@ -13,25 +13,18 @@ trait RookTrait
             # check if moving to the right
             if ($move->from_x < $move->to_x) {
                 for ($i = 1; $i <= $distance_x; $i++) {
-                    # check if there is a piece on the way
-                   if($distance_x==$i && $chessboard[$move->from_x + $i][$move->from_y] instanceof ChessPiece && $chessboard[$move->from_x+$i][$move->from_y]->get_color()!=$chessboard[$move->from_x][$move->from_y]->get_color()) {
+                    $move_to_field = $chessboard[$move->from_x + $i][$move->from_y];
+                    if($this->check_file_move($move_to_field, $i, $distance_x)){
                         return true;
-                    }elseif(!$chessboard[$move->from_x + $i][$move->from_y] instanceof ChessPiece){
-                       
-                    }else{
-                        return false;
                     }
                 }
+                return false;
                 # check if its moving to the left
             } elseif ($move->to_x < $move->from_x) {
                 for ($i = 1; $i <= $distance_x; $i++) {
-                    # check if there is a piece on the way
-                    if($distance_x==$i && $chessboard[$move->from_x - $i][$move->from_y] instanceof ChessPiece && $chessboard[$move->from_x-$i][$move->from_y]->get_color()!=$chessboard[$move->from_x][$move->from_y]->get_color()) {
+                    $move_to_field = $chessboard[$move->from_x - $i][$move->from_y];
+                    if($this->check_file_move($move_to_field, $i, $distance_x)){
                         return true;
-                    }elseif(!$chessboard[$move->from_x - $i][$move->from_y] instanceof ChessPiece){
-
-                    }else{
-                        return false;
                     }
                 }
             }
@@ -42,32 +35,35 @@ trait RookTrait
         if ($move->from_x == $move->to_x && $move->from_y != $move->to_y) {
             # check if moving up
             if($move->from_y<$move->to_y){
-                
                 for ($i=1; $i<= $distance_y; $i++) { 
-                    # check if there is a piece on the way
-                    if($distance_y==$i && $chessboard[$move->from_x][$move->from_y+$i] instanceof ChessPiece && $chessboard[$move->from_x][$move->from_y+$i]->get_color()!=$chessboard[$move->from_x][$move->from_y]->get_color()) {
+                    $move_to_field = $chessboard[$move->from_x][$move->from_y+$i];
+                    if($this->check_file_move($move_to_field, $i, $distance_y)){
                         return true;
-                    }elseif(!$chessboard[$move->from_x][$move->from_y+$i] instanceof ChessPiece){
-
-                    }else{
-                        return false;
                     }
                 }
                 # check if moving down
             }elseif ($move->to_y<$move->from_y) {
-                for ($i=1; $i<= $distance_y; $i++) { 
-                    # check if there is a piece on the way
-                    if($distance_y==$i && $chessboard[$move->from_x][$move->from_y-$i] instanceof ChessPiece && $chessboard[$move->from_x][$move->from_y-$i]->get_color()!=$chessboard[$move->from_x][$move->from_y]->get_color()) {
+                for ($i=1; $i<= $distance_y; $i++) {
+                    $move_to_field = $chessboard[$move->from_x][$move->from_y-$i]; # check if there is a piece on the way 
+                    if($this->check_file_move($move_to_field, $i, $distance_y)){
                         return true;
-                    }elseif(!$chessboard[$move->from_x][$move->from_y-$i] instanceof ChessPiece){
-
-                    }else{
-                        return false;
                     }
                 }
             }
             return true;
         }
+        return false;
+    }
+
+    private function check_file_move($move_to_field, $index, $distance){
+        if(!$move_to_field instanceof ChessPiece) // No piece on the way
+            {
+                return true;
+            }
+        if($distance==$index && $move_to_field instanceof ChessPiece) // Piece on last square is allowed
+            {
+                return true;
+            }
         return false;
     }
 }

--- a/src/logic/chesspieces/traits.php
+++ b/src/logic/chesspieces/traits.php
@@ -4,8 +4,8 @@ trait RookTrait
     public function check_legal_rookmove(mixed $chessboard, Move $move): bool
     {   
         # distance in squares
-        $distance_x = sqrt(pow(($move->to_x-$move->from_x),2)); 
-        $distance_y = sqrt(pow(($move->to_y-$move->from_y),2)); 
+        $distance_x = (int) sqrt(pow(($move->to_x-$move->from_x),2)); 
+        $distance_y = (int) sqrt(pow(($move->to_y-$move->from_y),2)); 
 
        # check if its horizontally
         if ($move->from_y == $move->to_y && $move->from_x != $move->to_x) {
@@ -54,7 +54,7 @@ trait BishopTrait{
         # check if its diagonal move
         if(pow($move->from_x-$move->to_x,2) == pow($move->from_y-$move->to_y,2)){
 
-            $distance = sqrt(pow($move->from_x-$move->to_x,2)); # distance in squares
+            $distance = (int) sqrt(pow($move->from_x-$move->to_x,2)); # distance in squares
             # top right 
             if($move->from_x<$move->to_x && $move->from_y<$move->to_y){
                 if(check_direction($chessboard, $move, $distance, "++")){
@@ -76,7 +76,6 @@ trait BishopTrait{
                 }else{
                     return false;
                 }
-                return false;
             # bottom right
             }elseif($move->from_x<$move->to_x && $move->from_y>$move->to_y){
                 if(check_direction($chessboard, $move, $distance, "+-")){
@@ -102,7 +101,7 @@ function piece_in_way(mixed $move_to_field, int $index, int $distance):bool
     return false;
 }
 
-function check_direction($chessboard, Move $move, int $distance, String $direction): bool
+function check_direction(mixed $chessboard, Move $move, int $distance, String $direction): bool
 {
     for ($i=1; $i <= $distance; $i++) { 
         $move_to_field = get_move_to_field($chessboard, $move, $direction, $i);
@@ -114,24 +113,24 @@ function check_direction($chessboard, Move $move, int $distance, String $directi
     return true;
 }
 
-function get_move_to_field(mixed $chessboard, Move $move, String $direction, $i):mixed
+function get_move_to_field(mixed $chessboard, Move $move, String $direction, int $index):mixed
 {
     if($direction == "+x"){
-        $move_to_field = $chessboard[$move->from_x + $i][$move->from_y];
+        $move_to_field = $chessboard[$move->from_x + $index][$move->from_y];
     }elseif($direction == "+y"){
-        $move_to_field = $chessboard[$move->from_x][$move->from_y + $i];
+        $move_to_field = $chessboard[$move->from_x][$move->from_y + $index];
     }elseif($direction == "-x"){
-        $move_to_field = $chessboard[$move->from_x - $i][$move->from_y];
+        $move_to_field = $chessboard[$move->from_x - $index][$move->from_y];
     }elseif($direction == "-y"){
-        $move_to_field = $chessboard[$move->from_x][$move->from_y - $i];
+        $move_to_field = $chessboard[$move->from_x][$move->from_y - $index];
     }elseif($direction == "++"){
-        $move_to_field = $chessboard[$move->from_x + $i][$move->from_y + $i];
+        $move_to_field = $chessboard[$move->from_x + $index][$move->from_y + $index];
     }elseif($direction == "--"){
-        $move_to_field = $chessboard[$move->from_x - $i][$move->from_y - $i];
+        $move_to_field = $chessboard[$move->from_x - $index][$move->from_y - $index];
     }elseif($direction == "+-"){
-        $move_to_field = $chessboard[$move->from_x + $i][$move->from_y - $i];
+        $move_to_field = $chessboard[$move->from_x + $index][$move->from_y - $index];
     }elseif($direction == "-+"){
-        $move_to_field = $chessboard[$move->from_x - $i][$move->from_y + $i];
+        $move_to_field = $chessboard[$move->from_x - $index][$move->from_y + $index];
     }else{
         throw new Exception("Invalid direction");
     }

--- a/src/logic/chesspieces/traits.php
+++ b/src/logic/chesspieces/traits.php
@@ -12,21 +12,13 @@ trait RookTrait
 
             # check if moving to the right
             if ($move->from_x < $move->to_x) {
-                for ($i = 1; $i <= $distance_x; $i++) {
-                    $move_to_field = $chessboard[$move->from_x + $i][$move->from_y];
-                    if(check_file_move($move_to_field, $i, $distance_x)){
-                        return true;
-                    }
-                    return false;
+                if(check_direction($chessboard, $move, $distance_x, "positiv", "x")){
+                    return true;
                 }
-                # check if its moving to the left
-            } elseif ($move->to_x < $move->from_x) {
-                for ($i = 1; $i <= $distance_x; $i++) {
-                    $move_to_field = $chessboard[$move->from_x - $i][$move->from_y];
-                    if(check_file_move($move_to_field, $i, $distance_x)){
-                        return true;
-                    }
-                    return false;
+                
+            } elseif ($move->to_x < $move->from_x) { # check if it a move to the left
+                if(check_direction($chessboard, $move, $distance_x, "negativ", "x")){
+                    return true;
                 }
             }
         }
@@ -35,27 +27,20 @@ trait RookTrait
         if ($move->from_x == $move->to_x && $move->from_y != $move->to_y) {
             # check if moving up
             if($move->from_y<$move->to_y){
-                for ($i=1; $i<= $distance_y; $i++) { 
-                    $move_to_field = $chessboard[$move->from_x][$move->from_y+$i];
-                    if(check_file_move($move_to_field, $i, $distance_x)){
-                        return true;
-                    }
-                    return false;
+                if(check_direction($chessboard, $move, $distance_y, "positiv", "y")){
+                    return true;
                 }
                 # check if moving down
             }elseif ($move->to_y<$move->from_y) {
-                for ($i=1; $i<= $distance_y; $i++) {
-                    $move_to_field = $chessboard[$move->from_x][$move->from_y-$i]; # check if there is a piece on the way 
-                    if(check_file_move($move_to_field, $i, $distance_x)){
-                        return true;
-                    }
-                    return false;
+                if(check_direction($chessboard, $move, $distance_y, "negativ", "y")){
+                    return true;
                 }
             }
-            return true;
+            return false;
         }
         return false;
     }
+
 
 
 }
@@ -67,54 +52,58 @@ trait BishopTrait{
         if(pow($move->from_x-$move->to_x,2) == pow($move->from_y-$move->to_y,2)){
 
             $distance = sqrt(pow($move->from_x-$move->to_x,2)); # distance in squares
-            $move_from_field = $chessboard[$move->from_x][$move->from_y];
-
 
             # top right - check if piece on the way
             if($move->from_x<$move->to_x && $move->from_y<$move->to_y){
                 for ($i=1; $i <= $distance; $i++) { 
                     $move_to_field = $chessboard[$move->from_x+$i][$move->from_y+$i];
-                    if(check_file_move($move_to_field, $i, $distance)){
+                    if(no_piece_in_way($move_to_field, $i, $distance)){
                         return true;
+                    }else{
+                        return false;
                     }
-                    return false;
                 }
+                
             # top left
             }elseif($move->from_x>$move->to_x && $move->from_y<$move->to_y){
                 for ($i=1; $i <= $distance; $i++) {
                     $move_to_field = $chessboard[$move->from_x-$i][$move->from_y+$i]; 
-                    if(check_file_move($move_to_field, $i, $distance)){
+                    if(no_piece_in_way($move_to_field, $i, $distance)){
                         return true;
+                    }else{
+                        return false;
                     }
-                    return false;
                 }
             # bottom left
             }elseif($move->from_x>$move->to_x && $move->from_y>$move->to_y){
                 for ($i=1; $i <= $distance; $i++) {
                     $move_to_field = $chessboard[$move->from_x-$i][$move->from_y-$i]; 
-                    if(check_file_move($move_to_field, $i, $distance)){
+                    if(no_piece_in_way($move_to_field, $i, $distance)){
                         return true;
+                    }else{
+                        return false;
                     }
-                    return false;
                 }
+                return false;
             # bottom right
             }elseif($move->from_x<$move->to_x && $move->from_y>$move->to_y){
                 for ($i=1; $i <= $distance; $i++) {
                     $move_to_field = $chessboard[$move->from_x+$i][$move->from_y-$i]; 
-                    if(check_file_move($move_to_field, $i, $distance)){
+                    if(no_piece_in_way($move_to_field, $i, $distance)){
                         return true;
+                    }else{
+                        return false;
                     }
-                    return false;
                 }
             }
-            return false;
         }
     return false; # not a diagonal move
     }
 
 }
 
- function check_file_move($move_to_field, $index, $distance){
+function no_piece_in_way(mixed $move_to_field, int $index, int $distance):bool
+{
     if($move_to_field instanceof ChessPiece){ // check if there is a piece on the way
         if($index==$distance){ // target square can be taken
             return true;
@@ -124,5 +113,28 @@ trait BishopTrait{
     }elseif($index==$distance){ // no piece on the way
         return true;
     } 
-    return false;
+    return true;
+}
+
+function check_direction($chessboard, Move $move, int $distance, String $sign, String $direction): bool
+{
+    for ($i = 1; $i <= $distance; $i++) {
+        if($sign == "negativ"){
+            $i = -$i;
+        }
+
+        if($direction == "x"){
+            $move_to_field = $chessboard[$move->from_x + $i][$move->from_y];
+        }elseif($direction == "y"){
+            $move_to_field = $chessboard[$move->from_x][$move->from_y + $i];
+        }
+        
+        if(no_piece_in_way($move_to_field, $i, $distance)){
+            
+        }else{
+            return false;
+        }
+        
+        return true;
+    }
 }

--- a/src/logic/logic.php
+++ b/src/logic/logic.php
@@ -69,10 +69,18 @@ class Logic
     private function check_rules(mixed $chessboard,Move $move, bool $whitesturn):bool
     {
         $this->castling_status="None";
-
-        if($chessboard[$move->from_x][$move->from_y]==""){
+        $move_from_field = $chessboard[$move->from_x][$move->from_y];
+        if($move_from_field==""){
             throw new Exception("No piece on this square");
         }
+
+        $move_to_field = $chessboard[$move->to_x][$move->to_y];
+        if($move_to_field instanceof ChessPiece){
+            if($move_from_field->get_color()==$move_to_field->get_color()){
+                $this->gamestatus_json = json_encode(['status' => 'illegal', 'message' => 'Cannot capture own piece', 'from' =>"$move->from_x$move->from_y", 'to' => "$move->to_x$move->to_y"]);    
+                return false;
+            }
+        }        
 
         if($chessboard[$move->to_x][$move->to_y] instanceof King){
             $this->gamestatus_json = json_encode(['status' => 'illegal', 'message' => 'Cannot capture King!', 'from' =>"$move->from_x$move->from_y", 'to' => "$move->to_x$move->to_y"]);    
@@ -84,8 +92,8 @@ class Logic
             return false;
         }
 
-        $piece = $chessboard[$move->from_x][$move->from_y];
-        if($piece->check_move_legal($chessboard,$move)==false){
+        
+        if($move_from_field->check_move_legal($chessboard,$move)==false){
           $this->gamestatus_json = json_encode(['status' => 'illegal', 'message' => 'Piece cannot move like that', 'from' =>"$move->from_x$move->from_y", 'to' => "$move->to_x$move->to_y"]);    
           return false;
         }


### PR DESCRIPTION
### Rook & Bishop refactoring 
I refactored the direction checks to reuse the code for every direction. Bishops and rooks are now both using the same methods to validate their moves.

### Stopped checking for the target square piece color in every check_move_legal function. Now logic just checks it generally to unload all the pieces.
Also deleted the method for it in chesspiece since it was barely used.
closes #87 